### PR TITLE
Slowing Down SPI SD Card speed

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -1207,7 +1207,7 @@
 // Uncomment ONE of the following items to use a slower SPI transfer
 // speed. This is usually required if you're getting volume init errors.
 //
-//#define SPI_SPEED SPI_HALF_SPEED
+#define SPI_SPEED SPI_HALF_SPEED
 //#define SPI_SPEED SPI_QUARTER_SPEED
 //#define SPI_SPEED SPI_EIGHTH_SPEED
 


### PR DESCRIPTION
Paul C from the facebook group "101 Hero (Unofficial)" mentioned he was
having SD init issues.
"RC8 needs Quarter or slower, RCBugFix needs Half or slower."