### PR TITLE
Adding DELTA_HEIGHT

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -449,6 +449,9 @@
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS (DELTA_SMOOTH_ROD_OFFSET-(DELTA_EFFECTOR_OFFSET)-(DELTA_CARRIAGE_OFFSET))
 
+  // height from z=0.00 to home position
+  #define DELTA_HEIGHT 107 // get this value from auto calibrat
+
   // Print surface diameter/2 minus unreachable space (avoid collisions with vertical towers).
   #define DELTA_PRINTABLE_RADIUS 50.0
 
@@ -958,7 +961,7 @@
 // For DELTA this is the top-center of the Cartesian print volume.
 //#define MANUAL_X_HOME_POS 0
 //#define MANUAL_Y_HOME_POS 0
-#define MANUAL_Z_HOME_POS 107 // Distance between the nozzle to printbed after homing
+#define MANUAL_Z_HOME_POS DELTA_HEIGHT // Distance between the nozzle to printbed after homing
 
 // Use "Z Safe Homing" to avoid homing with a Z probe outside the bed area.
 //


### PR DESCRIPTION
A recent change in RCBugFix upstream requires DELTA_HEIGHT to be set
instead of MANUAL_Z_HOME_POS (which is set to the former anyways).
Simply adding this in to keep it working with the latest release.